### PR TITLE
Support for ruby versions < 2.1

### DIFF
--- a/lib/imgix/rails/view_helper.rb
+++ b/lib/imgix/rails/view_helper.rb
@@ -11,7 +11,7 @@ module Imgix
         Imgix::Rails::ImageTag.new(source, options).render
       end
 
-      def ix_picture_tag(source, picture_tag_options:, imgix_default_options:, breakpoints:)
+      def ix_picture_tag(source, picture_tag_options: nil, imgix_default_options: nil, breakpoints: nil)
         Imgix::Rails::PictureTag.new(source, picture_tag_options, imgix_default_options, breakpoints).render
       end
     end


### PR DESCRIPTION
This change fixes an issue where the gem does not
support ruby versions less than 2.1